### PR TITLE
半角英数字は0.5文字プラスされる文字数カウンター

### DIFF
--- a/resources/views/memos/edit.blade.php
+++ b/resources/views/memos/edit.blade.php
@@ -23,12 +23,24 @@
     </div>
     <div class="form-group">
     <label for="memo_text">メモ内容:</label>
-    <textarea class="form-control" name="memo_text" cols="50" rows="10" id="memo_text" onKeyUp="countLength(value, 'textlength');">{{ $memo->memo_text }}</textarea>
-      <p id="textlength">0文字</p>
+    <textarea class="form-control" name="memo_text" cols="50" rows="10" id="memo_text" onkeyup="isCount(this)">{{ $memo->memo_text }}</textarea>
+    <p id="textlength">0文字</p>
       <script>
-        function countLength( text, field ) {
-            document.getElementById(field).innerHTML = text.length + "文字";
-        }
+        'use strict'
+
+        function isCount(obj) {
+          let value    = obj.value;
+          let count    = 0;
+          let halfSize = value.match(/[\da-zA-Z]/g);
+
+          if(halfSize) {
+            count = value.length - halfSize.length / 2
+          } else {
+            count = value.length;
+          };
+
+          document.getElementById('textlength').textContent = count + '文字';
+        };
       </script>
     </div>
 


### PR DESCRIPTION
半角英数字は0.5文字プラスされる文字数カウンターを作りました。

現在、スペースと記号は1文字になっています。仕様によって、正規表現のところ変えたら良さそうです。

また、バリデーションの部分は変えていないです。文字数が判定できているため、そのままJSのコードを書き足せば、できると思います〜。